### PR TITLE
universities-route-fix

### DIFF
--- a/Controllers/University/IUniversityController.cs
+++ b/Controllers/University/IUniversityController.cs
@@ -4,6 +4,6 @@ namespace Advisor.Controllers
 {
     public interface IUniversityController
     {
-        ActionResult Index(int? id);
+        ActionResult Index();
     }
 }

--- a/Controllers/University/UniversityController.cs
+++ b/Controllers/University/UniversityController.cs
@@ -16,26 +16,23 @@ namespace Advisor.Controllers
         }
 
         [Route("universities/{id?}", Name = "universities_page")]
-        public ActionResult Index(int? id)
+        public ActionResult Individual(int? id)
         {
-            if (id != null)
-            {
-                University uni = DB.Instance.Universities.Where(u => u.Id == id).SingleOrDefault();
-                if (uni == null)
-                {
-                    return View("/Views/Shared/404.cshtml");
-                }
+            University uni = DB.Instance.Universities.Where(u => u.Id == id).SingleOrDefault(); 
+            if (uni == null)
+            { 
+                return View("/Views/Shared/404.cshtml");
 
-                ViewBag.University = uni;
-                ViewBag.StatsData = LoadStats(uni);
-
-                return View("/Views/University/University.cshtml");
             }
 
-            return List();
+            ViewBag.University = uni; 
+            ViewBag.StatsData = LoadStats(uni);
+
+            return View("/Views/University/University.cshtml");
         }
 
-        private ActionResult List()
+        [Route("universities", Name = "universities_list")]
+        public ActionResult Index()
         {
             List<University> unis = DB.Instance.Universities.ToList();
             ViewBag.Universities = unis;

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -23,7 +23,7 @@
             <div class="navbar-collapse collapse">
                 @Html.Partial("_LoginPartial")
                 <ul class="nav navbar-nav navbar-right">
-                    <li><a href="@Url.RouteUrl("universities_page")">Universities</a></li>
+                    <li><a href="@Url.RouteUrl("universities_list")">Universities</a></li>
                     <li><a href="@Url.RouteUrl("review_page")">Leave a review!</a></li>
                     @if (User.IsInRole("Admin"))
                     {


### PR DESCRIPTION
Fixed a bug: when you tried to go to Universities from pages that had id (e.g. from individual faculty, university or study program view), you would go to "universities/{id}", instead of "universities/"